### PR TITLE
[init] Add perceval/__init__.py as in perceval

### DIFF
--- a/perceval/__init__.py
+++ b/perceval/__init__.py
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2015-2017 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import logging
+
+from ._version import __version__
+from .backend import find_backends
+
+__all__ = [__version__, find_backends]
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/setup.py
+++ b/setup.py
@@ -68,9 +68,6 @@ setup(name="perceval-opnfv",
           'perceval.backends',
           'perceval.backends.opnfv'
       ],
-      namespaces=[
-          'perceval.backends'
-      ],
       install_requires=[
           'requests>=2.7.0',
           'grimoirelab-toolkit>=0.1.0',

--- a/tests/test_functest.py
+++ b/tests/test_functest.py
@@ -20,19 +20,12 @@
 #
 
 import datetime
-import sys
 import unittest
 import unittest.mock
 
 import httpretty
-import pkg_resources
 import dateutil.tz
 import requests.exceptions
-
-# Hack to make sure that tests import the right packages
-# due to setuptools behaviour
-sys.path.insert(0, '..')
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.errors import BackendError


### PR DESCRIPTION
When installing this package after perceval, its (formerly empty) perceval/__init__.py file overwrites (or supersedes, depending on how it is installed) the one in the perceval package. That causes errors: see for example grimoirelab/perceval#190 or grimoirelab/perceval#171.

This is not the best fix, since it requires maintaining this file in sync in all perceval and perceval-* packackes, but for now, it does the trick.