### PR TITLE
[functest] Apply generic HTTP client to FuncTest

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -25,6 +25,6 @@ import unittest
 
 
 if __name__ == '__main__':
-    test_suite = unittest.TestLoader().discover('.', pattern='test*.py')
+    test_suite = unittest.TestLoader().discover('.', pattern='test_*.py')
     result = unittest.TextTestRunner(buffer=True).run(test_suite)
     sys.exit(not result.wasSuccessful())

--- a/tests/test_functest.py
+++ b/tests/test_functest.py
@@ -25,10 +25,8 @@ import unittest.mock
 
 import httpretty
 import dateutil.tz
-import requests.exceptions
 
 from perceval.backend import BackendCommandArgumentParser
-from perceval.errors import BackendError
 from perceval.utils import DEFAULT_DATETIME
 from perceval.backends.opnfv.functest import (Functest,
                                               FunctestClient,
@@ -276,23 +274,6 @@ class TestFunctestClient(unittest.TestCase):
         self.assertEqual(req.method, 'GET')
         self.assertRegex(req.path, '/api/v1/results')
         self.assertDictEqual(req.querystring, expected)
-
-    @httpretty.activate
-    @unittest.mock.patch('requests.get')
-    def test_connection_error(self, mock_get):
-        """Check if a connection error exception is raised after predefined tries"""
-
-        mock_get.side_effect = requests.exceptions.ConnectionError()
-
-        # Set up a mock HTTP server
-        setup_http_server()
-
-        # Call API
-        client = FunctestClient(FUNCTEST_URL)
-        from_date = datetime.datetime(2017, 6, 1, 10, 0, 0)
-
-        with self.assertRaises(BackendError):
-            _ = [r for r in client.results(from_date=from_date)]
 
 
 class TestFunctestCommand(unittest.TestCase):


### PR DESCRIPTION
The generic client is applied to the FuncTest backend. Now connection problems are transparently handled by the generic client.